### PR TITLE
Adds instructions to README for adding to a Rails app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,33 @@
+# turbolinks-source-gem
+
+Quickly add Turbolinks to your Rails app without the overhead of coffeescript and building the compiled JS from source.
+
+## Gemfile
+
+```ruby
+gem 'turbolinks-source', '~>5.0.0.beta5'
+```
+
+## Rails Configuration
+
+Give Rails an additional path to find assets in:
+
+```ruby
+# config/initializers/assets.rb
+
+Rails.application.config.assets.paths << Turbolinks::Source.asset_path
+```
+
+## Asset Inclusion
+
+Include Turbolinks in the list of scripts going down to the client:
+
+```javascript
+// app/assets/javascripts/application.js
+
+//= require jquery
+//= require turbolinks
+// ...your other includes here...
+```
+    
+Enjoy!


### PR DESCRIPTION
I've been including the full turbolinks repo until I found this gem that just includes the final compiled JS, which is probably all that most people need. There weren't any instructions for installing into Rails, so I added some!
